### PR TITLE
Add support for configuration as code plugin usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,11 @@
 			<artifactId>credentials</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.jenkins</groupId>
+			<artifactId>configuration-as-code</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PriorityConfiguration.java
@@ -62,6 +62,7 @@ import jenkins.advancedqueue.jobinclusion.JobInclusionStrategy;
 import jenkins.advancedqueue.priority.PriorityStrategy;
 import jenkins.advancedqueue.sorter.ItemInfo;
 import jenkins.advancedqueue.sorter.QueueItemCache;
+import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
@@ -78,7 +79,7 @@ import org.kohsuke.stapler.StaplerResponse;
  * @since 2.0
  */
 @Extension
-public class PriorityConfiguration extends Descriptor<PriorityConfiguration> implements RootAction, Describable<PriorityConfiguration> {
+public class PriorityConfiguration extends GlobalConfiguration implements RootAction {
 
 	private final static Logger LOGGER = Logger.getLogger(PriorityConfiguration.class.getName());
 
@@ -88,7 +89,7 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 	private List<JobGroup> jobGroups;
 
 	public PriorityConfiguration() {
-		super(PriorityConfiguration.class);
+		super();
 		jobGroups = new LinkedList<JobGroup>();
 		load();
 		//
@@ -147,6 +148,11 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 		return jobGroups;
 	}
 
+	public void setJobGroups(List<JobGroup> jobGroups) {
+		this.jobGroups = jobGroups;
+		save();
+	}
+
 	public JobGroup getJobGroup(int id) {
 		return id2jobGroup.get(id);
 	}
@@ -184,10 +190,6 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 		}
 		save();
 		rsp.sendRedirect(Jenkins.get().getRootUrl());
-	}
-
-	public Descriptor<PriorityConfiguration> getDescriptor() {
-		return this;
 	}
 
 	public FormValidation doCheckJobPattern(@QueryParameter String value) throws IOException, ServletException {
@@ -238,7 +240,7 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 		return priorityCallback.setPrioritySelection(PrioritySorterConfiguration.get().getStrategy().getDefaultPriority());
 	}
 
-        @CheckForNull
+		@CheckForNull
 	public JobGroup getJobGroup(@Nonnull PriorityConfigurationCallback priorityCallback, @Nonnull Job<?, ?> job) {
 		if (!(job instanceof TopLevelItem)) {
 			priorityCallback.addDecisionLog(0, "Job is not a TopLevelItem [" + job.getClass().getName() + "] ...");
@@ -301,7 +303,7 @@ public class PriorityConfiguration extends Descriptor<PriorityConfiguration> imp
 	}
 
 	static public PriorityConfiguration get() {
-		return (PriorityConfiguration) Jenkins.get().getDescriptor(PriorityConfiguration.class);
-	}
+        return GlobalConfiguration.all().get(PriorityConfiguration.class);
+    }
 
 }

--- a/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
+++ b/src/main/java/jenkins/advancedqueue/PrioritySorterConfiguration.java
@@ -164,10 +164,6 @@ public class PrioritySorterConfiguration extends GlobalConfiguration {
 		}
 	}
 
-	static public PrioritySorterConfiguration get() {
-		return (PrioritySorterConfiguration) Jenkins.get().getDescriptor(PrioritySorterConfiguration.class);
-	}
-
 	@DataBoundSetter
 	public void setOnlyAdminsMayEditPriorityConfiguration(boolean onlyAdminsMayEditPriorityConfiguration) {
 		this.onlyAdminsMayEditPriorityConfiguration = onlyAdminsMayEditPriorityConfiguration;
@@ -181,4 +177,7 @@ public class PrioritySorterConfiguration extends GlobalConfiguration {
 		save();
 	}
 
+	public static PrioritySorterConfiguration get() {
+		return GlobalConfiguration.all().get(PrioritySorterConfiguration.class);
+	}
 }

--- a/src/test/java/jenkins/advancedqueue/test/ConfigurationAsCodeTest.java
+++ b/src/test/java/jenkins/advancedqueue/test/ConfigurationAsCodeTest.java
@@ -1,0 +1,59 @@
+package jenkins.advancedqueue.test;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import static org.junit.Assert.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import io.jenkins.plugins.casc.ConfigurationAsCode;
+import io.jenkins.plugins.casc.ConfiguratorException;
+
+import jenkins.advancedqueue.JobGroup;
+import jenkins.advancedqueue.PrioritySorterConfiguration;
+import jenkins.advancedqueue.PriorityConfiguration;
+import jenkins.advancedqueue.jobinclusion.strategy.FolderBasedJobInclusionStrategy;
+import jenkins.advancedqueue.jobinclusion.strategy.AllJobsJobInclusionStrategy;
+
+public class ConfigurationAsCodeTest {
+
+	@Rule public JenkinsRule r = new JenkinsRule();
+
+	@Test
+	public void PrioritySorterConfiguration() throws ConfiguratorException {
+		ConfigurationAsCode.get().configure(ConfigurationAsCodeTest.class.getResource("/jcasc/PrioritySorterConfiguration.yaml").toString());
+		PrioritySorterConfiguration prioSorterCfg = PrioritySorterConfiguration.get();
+		assertThat(prioSorterCfg.getOnlyAdminsMayEditPriorityConfiguration(), is(true));
+		assertThat(prioSorterCfg.getStrategy().getDefaultPriority(), is(3));
+		assertThat(prioSorterCfg.getStrategy().getNumberOfPriorities(), is(5));
+	}
+
+	@Test
+	public void PriorityConfiguration() throws ConfiguratorException {
+		ConfigurationAsCode.get().configure(ConfigurationAsCodeTest.class.getResource("/jcasc/PriorityConfiguration.yaml").toString());
+		PriorityConfiguration prioCfg = PriorityConfiguration.get();
+		assertThat(prioCfg.getJobGroups().size(), is(2));
+
+		JobGroup jobGroupFirst = prioCfg.getJobGroups().get(0);
+		assertThat(jobGroupFirst.getId(), is(0));
+		assertThat(jobGroupFirst.getDescription(), is("Complex"));
+		assertThat(jobGroupFirst.isRunExclusive(), is(true));
+		assertThat(jobGroupFirst.isUsePriorityStrategies(), is(true));
+		assertThat(jobGroupFirst.getPriorityStrategies().size(), is(6));
+		assertThat(jobGroupFirst.getJobGroupStrategy().getClass(), is(FolderBasedJobInclusionStrategy.class));
+
+		FolderBasedJobInclusionStrategy folderBasedStrategy = (FolderBasedJobInclusionStrategy) jobGroupFirst.getJobGroupStrategy();
+		assertThat(folderBasedStrategy.getFolderName(), is("Jenkins"));
+
+		JobGroup jobGroupSecond = prioCfg.getJobGroups().get(1);
+		assertThat(jobGroupSecond.getId(), is(1));
+		assertThat(jobGroupSecond.getDescription(), is("Simple"));
+		assertThat(jobGroupSecond.getPriorityStrategies().size(), is(0));
+		assertThat(jobGroupSecond.isRunExclusive(), is(false));
+		assertThat(jobGroupSecond.isUsePriorityStrategies(), is(false));
+		assertThat(jobGroupSecond.getJobGroupStrategy().getClass(), is(AllJobsJobInclusionStrategy.class));
+	}
+}

--- a/src/test/resources/jcasc/PriorityConfiguration.yaml
+++ b/src/test/resources/jcasc/PriorityConfiguration.yaml
@@ -1,0 +1,29 @@
+---
+unclassified:
+  priorityConfiguration:
+    jobGroups:
+      - id: 0
+        priority: 1
+        description: "Complex"
+        runExclusive: true
+        usePriorityStrategies: true
+        priorityStrategies:
+          - userIdCauseStrategy:
+              priority: 1
+          - upstreamCauseStrategy
+          - userIdCauseStrategy:
+              priority: 3
+          - cLICauseStrategy:
+              priority: 4
+          - jobPropertyStrategy
+          - buildParameterStrategy:
+              parameterName: priority
+        jobGroupStrategy:
+          folderBased:
+            folderName: "Jenkins"
+      - id: 1
+        priority: 2
+        description: "Simple"
+        runExclusive: false
+        usePriorityStrategies: false
+        jobGroupStrategy: allJobs

--- a/src/test/resources/jcasc/PrioritySorterConfiguration.yaml
+++ b/src/test/resources/jcasc/PrioritySorterConfiguration.yaml
@@ -1,0 +1,8 @@
+---
+unclassified:
+  prioritySorterConfiguration:
+    onlyAdminsMayEditPriorityConfiguration: true
+    strategy:
+      absoluteStrategy:
+        defaultPriority: 3
+        numberOfPriorities: 5

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,2 @@
+handlers= java.util.logging.ConsoleHandler
+.level= FINER


### PR DESCRIPTION
The configuration for the priority sorter plugin can be defined with
the [configuration as code plugin](https://github.com/jenkinsci/configuration-as-code-plugin).

This is the example from the junit test resource file `PriorityConfiguration.yaml`
```
unclassified:
  priorityConfiguration:
    jobGroups:
      - id: 0
        priority: 1
        description: "Complex"
        runExclusive: true
        usePriorityStrategies: true
        priorityStrategies:
          - userIdCauseStrategy:
              priority: 1
          - upstreamCauseStrategy
          - userIdCauseStrategy:
              priority: 3
          - cLICauseStrategy:
              priority: 4
          - jobPropertyStrategy
          - buildParameterStrategy:
              parameterName: priority
        jobGroupStrategy:
          folderBased:
            folderName: "Jenkins"
      - id: 1
        priority: 2
        description: "Simple"
        runExclusive: false
        usePriorityStrategies: false
        jobGroupStrategy: allJobs
```